### PR TITLE
Remote Scanning, Beacon Fixes, Static Friendly Names

### DIFF
--- a/apps.yaml.example
+++ b/apps.yaml.example
@@ -24,6 +24,14 @@ home_presence_app:
   #pin_thread: 3
   #log: apps_log
   #log_level: DEBUG
+
+  # Note: known_devices listed here will be added to each monitor instance.
+  # known_beacons will not, as there is currently no method in montior.sh
+  # to add beacons over mqtt. Beacons you wish to track must still be added here
+  # as well as in the KNOWN_BEACON_ADDRESSES files for each tracker, otherwise
+  # they will be ignored.
   known_devices:
-    - xx:xx:xx:xx:xx:xx Odianosen's iPhone
-    - xx:xx:xx:xx:xx:xx Nkiruka's iPad
+    - xx:xx:xx:xx:xx:xx Odianosen_iPhone
+    - xx:xx:xx:xx:xx:xx Nkiruka_iPad
+  known_beacons:
+    - xx:xx:xx:xx:xx:xx Nkiruka_iBeacon

--- a/apps.yaml.example
+++ b/apps.yaml.example
@@ -25,13 +25,15 @@ home_presence_app:
   #log: apps_log
   #log_level: DEBUG
 
-  # Note: known_devices listed here will be added to each monitor instance.
-  # known_beacons will not, as there is currently no method in montior.sh
-  # to add beacons over mqtt. Beacons you wish to track must still be added here
-  # as well as in the KNOWN_BEACON_ADDRESSES files for each tracker, otherwise
-  # they will be ignored.
+  # known_devices listed here will be added to each monitor instance via MQTT.
   known_devices:
     - xx:xx:xx:xx:xx:xx Odianosen_iPhone
     - xx:xx:xx:xx:xx:xx Nkiruka_iPad
+
+  # known_beacons listed here should be added to each monitor instance's
+  # known_beacon_addresses file manually as there is no MQTT method to do so.
+  # However, if the MAC/ID is added here, it will still be tracked appropriately. 
   known_beacons:
-    - xx:xx:xx:xx:xx:xx Nkiruka_iBeacon
+    - xx:xx:xx:xx:xx:xx Nkiruka_BLE_Beacon
+    - 00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx-Major-minor Nkiruka_iBeacon_ID
+  

--- a/home_presence_app.py
+++ b/home_presence_app.py
@@ -162,6 +162,16 @@ class HomePresenceApp(ad.ADBase):
         except ValueError:
             pass
 
+        # Handle request for immediate scan via MQTT
+        if action == "ad_scan_now":
+            self.mqtt.set_state(
+                self.monitor_entity,
+                state="scan",
+                attributes={"locations": [], "scan_type": payload},
+                replace=True,
+            )
+            return
+
         # Determine which scanner initiated the message
         location = "unknown"
         if isinstance(payload_json, dict) and "identity" in payload_json:


### PR DESCRIPTION
Updates on this branch include:

- Ability to force Monitor-App to initiate an immediate scan from all monitors with a MQTT message sent to the `../ad_scan_now` topic.
- Better handling of Known Beacons.
    - Previously beacons were just ignored by this app, or an error occurred when trying to add sensors.
    - New update adds `known_beacons` to `apps.yaml` and will ignore beacons not listed there.
    - Note: There is no ability to add known beacon addresses from this app to each monitor like static addresses. New beacon addresses will need to be added to each monitor instance's `KNOWN_BEACON_ADDRESSES` file as well as in `apps.yaml`
- Friendly Names will no longer be pulled from the `name` property sent by monitor, they'll only be pulled from the topic. This is to prevent the friendly name from changing if a device sends a different or blank name sometimes in the payload (happens with some beacons).